### PR TITLE
Unobserved task exceptions

### DIFF
--- a/Rackspace.Threading/CoreTaskExtensions.cs
+++ b/Rackspace.Threading/CoreTaskExtensions.cs
@@ -116,7 +116,10 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (task.Status == TaskStatus.RanToCompletion || (supportsErrors && task.Status == TaskStatus.Faulted))
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromTask(t);
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             TaskContinuationOptions failedContinuationOptions = supportsErrors ? TaskContinuationOptions.OnlyOnCanceled : TaskContinuationOptions.NotOnRanToCompletion;
@@ -226,7 +229,10 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (task.Status == TaskStatus.RanToCompletion || (supportsErrors && task.Status == TaskStatus.Faulted))
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromTask(t);
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             TaskContinuationOptions failedContinuationOptions = supportsErrors ? TaskContinuationOptions.OnlyOnCanceled : TaskContinuationOptions.NotOnRanToCompletion;
@@ -332,7 +338,10 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (task.Status == TaskStatus.RanToCompletion || (supportsErrors && task.Status == TaskStatus.Faulted))
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromTask(t, default(VoidResult));
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             TaskContinuationOptions failedContinuationOptions = supportsErrors ? TaskContinuationOptions.OnlyOnCanceled : TaskContinuationOptions.NotOnRanToCompletion;
@@ -438,7 +447,10 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (task.Status == TaskStatus.RanToCompletion || (supportsErrors && task.Status == TaskStatus.Faulted))
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromTask(t, default(VoidResult));
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             TaskContinuationOptions failedContinuationOptions = supportsErrors ? TaskContinuationOptions.OnlyOnCanceled : TaskContinuationOptions.NotOnRanToCompletion;
@@ -888,9 +900,14 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (t.Status == TaskStatus.RanToCompletion)
+                        {
                             completionSource.SetFromTask(task, default(VoidResult));
+                        }
                         else
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromFailedTask(t);
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             return completionSource.Task;
@@ -955,9 +972,14 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (t.Status == TaskStatus.RanToCompletion)
+                        {
                             completionSource.SetFromTask(task);
+                        }
                         else
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromFailedTask(t);
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             return completionSource.Task;
@@ -1020,9 +1042,14 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (t.Status == TaskStatus.RanToCompletion)
+                        {
                             completionSource.SetFromTask(task, default(VoidResult));
+                        }
                         else
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromFailedTask(t);
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             return completionSource.Task;
@@ -1088,9 +1115,14 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (t.Status == TaskStatus.RanToCompletion)
+                        {
                             completionSource.SetFromTask(task);
+                        }
                         else
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromFailedTask(t);
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             return completionSource.Task;
@@ -1204,7 +1236,10 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (task.Status == TaskStatus.RanToCompletion || (supportsErrors && task.Status == TaskStatus.Faulted))
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromTask(t);
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             TaskContinuationOptions failedContinuationOptions = supportsErrors ? TaskContinuationOptions.OnlyOnCanceled : TaskContinuationOptions.NotOnRanToCompletion;
@@ -1324,7 +1359,10 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (task.Status == TaskStatus.RanToCompletion || (supportsErrors && task.Status == TaskStatus.Faulted))
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromTask(t);
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             TaskContinuationOptions failedContinuationOptions = supportsErrors ? TaskContinuationOptions.OnlyOnCanceled : TaskContinuationOptions.NotOnRanToCompletion;
@@ -1436,7 +1474,10 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (task.Status == TaskStatus.RanToCompletion || (supportsErrors && task.Status == TaskStatus.Faulted))
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromTask(t, default(VoidResult));
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             TaskContinuationOptions failedContinuationOptions = supportsErrors ? TaskContinuationOptions.OnlyOnCanceled : TaskContinuationOptions.NotOnRanToCompletion;
@@ -1549,7 +1590,10 @@ namespace Rackspace.Threading
                     t =>
                     {
                         if (task.Status == TaskStatus.RanToCompletion || (supportsErrors && task.Status == TaskStatus.Faulted))
+                        {
+                            IgnoreAntecedentExceptions(task);
                             completionSource.SetFromTask(t, default(VoidResult));
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
 
             TaskContinuationOptions failedContinuationOptions = supportsErrors ? TaskContinuationOptions.OnlyOnCanceled : TaskContinuationOptions.NotOnRanToCompletion;
@@ -1632,6 +1676,31 @@ namespace Rackspace.Threading
             }
 
             return exception;
+        }
+
+        /// <summary>
+        /// Observe any exceptions from the specified <paramref name="task"/>, since its result is being ignored due to
+        /// another condition or task.
+        /// </summary>
+        /// <remarks>
+        /// <para>This is generally called when a continuation task's faulted or canceled state is about to be
+        /// propagated instead of the final state of <paramref name="task"/>. This is similar to the case in C# where an
+        /// exception is thrown in an exception block while another exception has already been thrown. The first
+        /// exception is silently dropped. In the Task Parallel Library, the equivalent is "observing" the exception
+        /// from the antecedent task by accessing its <see cref="Task.Exception"/> property.
+        /// </para>
+        /// </remarks>
+        /// <param name="task">The antecedent task.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="task"/> is <see langword="null"/>.</exception>
+        private static void IgnoreAntecedentExceptions(Task task)
+        {
+            if (task == null)
+                throw new ArgumentNullException("task");
+
+            if (!task.IsFaulted)
+                return;
+
+            Exception ignored = task.Exception;
         }
 
         /// <summary>

--- a/Rackspace.Threading/CoreTaskExtensions.cs
+++ b/Rackspace.Threading/CoreTaskExtensions.cs
@@ -1560,6 +1560,33 @@ namespace Rackspace.Threading
         }
 
         /// <summary>
+        /// This method ensures the exception for a faulted task is "observed", i.e. the <see cref="Task.Exception"/>
+        /// property will be accessed if the task enters the <see cref="TaskStatus.Faulted"/> state.
+        /// </summary>
+        /// <remarks>
+        /// <para>Prior to .NET 4.5, failing to observe the <see cref="Task.Exception"/> property for a faulted task
+        /// would terminate the process.</para>
+        /// </remarks>
+        /// <typeparam name="TTask">The specific type of task.</typeparam>
+        /// <param name="task">The antecedent task.</param>
+        /// <returns>The input argument <paramref name="task"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="task"/> is <see langword="null"/>.</exception>
+        public static TTask ObserveExceptions<TTask>(this TTask task)
+            where TTask : Task
+        {
+            if (task == null)
+                throw new ArgumentNullException("task");
+
+            task.ContinueWith(
+                t =>
+                {
+                    Exception ignored = t.Exception;
+                }, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted);
+
+            return task;
+        }
+
+        /// <summary>
         /// Attempts to gets the first unwrapped exception from a faulted or canceled task
         /// as an instance of <typeparamref name="TException"/>.
         /// </summary>

--- a/Rackspace.Threading/TaskBlocks.cs
+++ b/Rackspace.Threading/TaskBlocks.cs
@@ -262,10 +262,10 @@ namespace Rackspace.Threading
                     if (bodyTask == null)
                         throw new InvalidOperationException("The Task provided by the 'body' delegate cannot be null.");
 
-                    currentTask = bodyTask.Select(continuation).Finally(handleErrors);
+                    currentTask = bodyTask.Select(continuation).Finally(handleErrors).ObserveExceptions();
                 };
 
-            currentTask = CompletedTask.Default.Select(continuation).Finally(handleErrors);
+            currentTask = CompletedTask.Default.Select(continuation).Finally(handleErrors).ObserveExceptions();
             return taskCompletionSource.Task;
         }
 
@@ -347,10 +347,10 @@ namespace Rackspace.Threading
                     if (bodyTask == null)
                         throw new InvalidOperationException("The Task provided by the 'body' delegate cannot be null.");
 
-                    currentTask = bodyTask.Then(conditionContinuation).Select(continuation).Finally(statusCheck);
+                    currentTask = bodyTask.Then(conditionContinuation).Select(continuation).Finally(statusCheck).ObserveExceptions();
                 };
 
-            currentTask = CompletedTask.Default.Then(conditionContinuation).Select(continuation).Finally(statusCheck);
+            currentTask = CompletedTask.Default.Then(conditionContinuation).Select(continuation).Finally(statusCheck).ObserveExceptions();
             return taskCompletionSource.Task;
         }
     }

--- a/Tests/UnitTest.RackspaceThreading/TestDelayedTask_WhenAny.cs
+++ b/Tests/UnitTest.RackspaceThreading/TestDelayedTask_WhenAny.cs
@@ -187,8 +187,8 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(2 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions(),
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(2 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions(),
                 };
 
             Task<Task> delayed = DelayedTask.WhenAny(tasks);
@@ -250,7 +250,7 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Select(_ => string.Empty),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector)
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions()
                 };
             Task<Task> delayed = DelayedTask.WhenAny(tasks);
             Assert.IsFalse(delayed.IsCompleted);
@@ -282,7 +282,7 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Then(_ => CompletedTask.Canceled()),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector)
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions()
                 };
             Task<Task> delayed = DelayedTask.WhenAny(tasks);
             Assert.IsFalse(delayed.IsCompleted);
@@ -511,8 +511,8 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(2 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions(),
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(2 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions(),
                 };
 
             Task<Task> delayed = DelayedTask.WhenAny(tasks);
@@ -574,7 +574,7 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Select(_ => string.Empty),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector)
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions()
                 };
             Task<Task> delayed = DelayedTask.WhenAny(tasks);
             Assert.IsFalse(delayed.IsCompleted);
@@ -606,7 +606,7 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Then(_ => CompletedTask.Canceled()),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector)
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions()
                 };
             Task<Task> delayed = DelayedTask.WhenAny(tasks);
             Assert.IsFalse(delayed.IsCompleted);
@@ -837,8 +837,8 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(2 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions(),
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(2 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions(),
                 };
 
             Task<Task<string>> delayed = DelayedTask.WhenAny(tasks);
@@ -900,7 +900,7 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Select(_ => string.Empty),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector)
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions()
                 };
             Task<Task<string>> delayed = DelayedTask.WhenAny(tasks);
             Assert.IsFalse(delayed.IsCompleted);
@@ -932,7 +932,7 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Then(_ => CompletedTask.Canceled<string>()),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector)
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions()
                 };
             Task<Task<string>> delayed = DelayedTask.WhenAny(tasks);
             Assert.IsFalse(delayed.IsCompleted);
@@ -1163,8 +1163,8 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(2 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector),
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions(),
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(2 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions(),
                 };
 
             Task<Task<string>> delayed = DelayedTask.WhenAny(tasks);
@@ -1226,7 +1226,7 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Select(_ => string.Empty),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector)
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions()
                 };
             Task<Task<string>> delayed = DelayedTask.WhenAny(tasks);
             Assert.IsFalse(delayed.IsCompleted);
@@ -1259,7 +1259,7 @@ namespace UnitTest.RackspaceThreading
                 new[]
                 {
                     DelayedTask.Delay(TimeSpan.FromMilliseconds(1 * TimingGranularity.TotalMilliseconds)).Then(_ => CompletedTask.Canceled<string>()),
-                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector)
+                    DelayedTask.Delay(TimeSpan.FromMilliseconds(3 * TimingGranularity.TotalMilliseconds)).Select(exceptionSelector).ObserveExceptions()
                 };
             Task<Task<string>> delayed = DelayedTask.WhenAny(tasks);
             Assert.IsFalse(delayed.IsCompleted);


### PR DESCRIPTION
Fixes #89

* Make sure tests fail if a faulted task is not observed.
* Add the `CoreTaskExtensions.ObserveExceptions` method to help users targeting .NET 3.5 and .NET 4.0 avoid process-terminating conditions.
* Make sure the faulted state of antecedents is observed if the result is ignored due to an exception thrown by a continuation task.