### PR TITLE
Restore timing values to their defaults

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 version: 1.0.{build}
 configuration: Release
 environment:
-  DELAY_TOLERANCE_MS: 400
-  TIMING_GRANULARITY_MS: 400
+  DELAY_TOLERANCE_MS: 25
+  TIMING_GRANULARITY_MS: 10
 init:
 - git config --global core.autocrlf true
 build_script:


### PR DESCRIPTION
Now that the build is running on a faster AppVeyor account, the timing overrides are no longer necessary to ensure the tests pass.